### PR TITLE
Return code conformity & TYPE parameter parsing

### DIFF
--- a/FubarDev.FtpServer/CommandHandlers/MdtmCommandHandler.cs
+++ b/FubarDev.FtpServer/CommandHandlers/MdtmCommandHandler.cs
@@ -59,7 +59,7 @@ namespace FubarDev.FtpServer.CommandHandlers
                 foundEntry = await Data.FileSystem.SetMacTimeAsync(fileInfo.Entry, modificationTime, null, null, cancellationToken);
             }
 
-            return new FtpResponse(220, $"{foundEntry.LastWriteTime?.ToUniversalTime():yyyyMMddHHmmss.fff}");
+            return new FtpResponse(213, $"{foundEntry.LastWriteTime?.ToUniversalTime():yyyyMMddHHmmss.fff}");
         }
     }
 }

--- a/FubarDev.FtpServer/CommandHandlers/NoOpCommandHandler.cs
+++ b/FubarDev.FtpServer/CommandHandlers/NoOpCommandHandler.cs
@@ -27,7 +27,7 @@ namespace FubarDev.FtpServer.CommandHandlers
         /// <inheritdoc/>
         public override Task<FtpResponse> Process(FtpCommand command, CancellationToken cancellationToken)
         {
-            return Task.FromResult(new FtpResponse(220, "NOOP command successful."));
+            return Task.FromResult(new FtpResponse(200, "NOOP command successful."));
         }
     }
 }

--- a/FubarDev.FtpServer/CommandHandlers/SizeCommandHandler.cs
+++ b/FubarDev.FtpServer/CommandHandlers/SizeCommandHandler.cs
@@ -42,7 +42,7 @@ namespace FubarDev.FtpServer.CommandHandlers
             if (fileInfo?.Entry == null)
                 return new FtpResponse(550, $"File not found ({fileName}).");
 
-            return new FtpResponse(220, $"{fileInfo.Entry.Size}");
+            return new FtpResponse(213, $"{fileInfo.Entry.Size}");
         }
     }
 }

--- a/FubarDev.FtpServer/CommandHandlers/StruCommandHandler.cs
+++ b/FubarDev.FtpServer/CommandHandlers/StruCommandHandler.cs
@@ -29,7 +29,7 @@ namespace FubarDev.FtpServer.CommandHandlers
         public override Task<FtpResponse> Process(FtpCommand command, CancellationToken cancellationToken)
         {
             if (string.Equals(command.Argument, "F", StringComparison.OrdinalIgnoreCase))
-                return Task.FromResult(new FtpResponse(220, "Structure set to File."));
+                return Task.FromResult(new FtpResponse(200, "Structure set to File."));
             return Task.FromResult(new FtpResponse(504, $"File structure {command.Argument} not supported."));
         }
     }

--- a/FubarDev.FtpServer/FtpTransferMode.cs
+++ b/FubarDev.FtpServer/FtpTransferMode.cs
@@ -125,6 +125,8 @@ namespace FubarDev.FtpServer
 
         private void ParseInterpretationMode(string interpretationMode)
         {
+            interpretationMode = interpretationMode.Trim();
+
             if (FileType == FtpFileType.Ascii || FileType == FtpFileType.Ebcdic)
             {
                 if (string.IsNullOrEmpty(interpretationMode))


### PR DESCRIPTION
Hi FubarDev,

Here are two other changes.  One fixes the return codes of several commands to conform with their respective RFCs (You might want to double check that I got them right).  The other, fixes an issue with the TYPE command interpretation mode parameter parsing, regarding white space.

If you don't want to spin another pkg, that's fine.  I'm trying things out in my particular integration environment, so I would be fine with just using a local build until you feel the need to post to nuget.

Cheers,
_mutac