### PR TITLE
Make stream buffer size configurable.

### DIFF
--- a/FubarDev.FtpServer.FileSystem.DotNet/DotNetFileSystemProvider.cs
+++ b/FubarDev.FtpServer.FileSystem.DotNet/DotNetFileSystemProvider.cs
@@ -22,6 +22,8 @@ namespace FubarDev.FtpServer.FileSystem.DotNet
 
         private readonly bool _useUserIdAsSubFolder;
 
+        private readonly int _streamBufferSize;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DotNetFileSystemProvider"/> class.
         /// </summary>
@@ -36,10 +38,22 @@ namespace FubarDev.FtpServer.FileSystem.DotNet
         /// </summary>
         /// <param name="rootPath">The root path for all users</param>
         /// <param name="useUserIdAsSubFolder">Use the user id as subfolder?</param>
-        public DotNetFileSystemProvider([NotNull] string rootPath, bool useUserIdAsSubFolder)
+        public DotNetFileSystemProvider ([NotNull] string rootPath, bool useUserIdAsSubFolder)
+            : this (rootPath, useUserIdAsSubFolder, DotNetFileSystem.DEFAULT_STREAM_BUFFER_SIZE)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DotNetFileSystemProvider"/> class.
+        /// </summary>
+        /// <param name="rootPath">The root path for all users</param>
+        /// <param name="useUserIdAsSubFolder">Use the user id as subfolder?</param>
+        /// <param name="streamBufferSize">Buffer size to be used in async IO methods</param>
+        public DotNetFileSystemProvider([NotNull] string rootPath, bool useUserIdAsSubFolder, int streamBufferSize)
         {
             _rootPath = rootPath;
             _useUserIdAsSubFolder = useUserIdAsSubFolder;
+            _streamBufferSize = streamBufferSize;
         }
 
         /// <summary>
@@ -58,7 +72,7 @@ namespace FubarDev.FtpServer.FileSystem.DotNet
                 path = Path.Combine(path, userId);
             }
 
-            return Task.FromResult<IUnixFileSystem>(new DotNetFileSystem(path, AllowNonEmptyDirectoryDelete));
+            return Task.FromResult<IUnixFileSystem>(new DotNetFileSystem(path, AllowNonEmptyDirectoryDelete, _streamBufferSize));
         }
     }
 }


### PR DESCRIPTION
Previously it was using 4096 bytes for Stream.CopyToAsync method, which provides low performance when transferring large files.
Changed to allow to configure stream buffer size for DotNetFileSystemProvider and changed constructors to allow default size of 4096 for backward compatibility.