### PR TITLE
Fix invalid datetime format if LastWriteTime is NULL or last year

### DIFF
--- a/FubarDev.FtpServer/ListFormatters/LongListFormatter.cs
+++ b/FubarDev.FtpServer/ListFormatters/LongListFormatter.cs
@@ -5,6 +5,7 @@
 // <author>Mark Junker</author>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Globalization;
 
 using FubarDev.FtpServer.FileSystem;
@@ -25,9 +26,13 @@ namespace FubarDev.FtpServer.ListFormatters
 
         private static string BuildLine(IUnixFileSystemEntry entry, IUnixFileEntry fileEntry, string name)
         {
+            var lastWriteDate = entry.LastWriteTime ?? new DateTimeOffset(new DateTime(1970, 01, 01));
+            var format = lastWriteDate.Year == DateTimeOffset.UtcNow.Year
+                ? "{0}{1}{2}{3} {4} {5} {6} {7} {8:MMM dd HH:mm} {9}"
+                : "{0}{1}{2}{3} {4} {5} {6} {7} {8:MMM dd yyyy} {9}";
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "{0}{1}{2}{3} {4} {5} {6} {7:D13} {8:MMM dd HH:mm} {9}",
+                format,
                 fileEntry == null ? "d" : "-",
                 BuildAccessMode(entry.Permissions.User),
                 BuildAccessMode(entry.Permissions.Group),
@@ -36,7 +41,7 @@ namespace FubarDev.FtpServer.ListFormatters
                 entry.Owner,
                 entry.Group,
                 fileEntry?.Size ?? 0,
-                entry.LastWriteTime,
+                lastWriteDate,
                 name);
         }
 


### PR DESCRIPTION
If LastWriteTime was NULL or something other than the current year it would result in ListFormatter to render the date as empty or the given date this year.

I've fixed this by setting the date to 1970-01-01 if it's NULL, and added a check on whether the year is current or not.