### PR TITLE
Fix V3038

### DIFF
--- a/FubarDev.FtpServer.FileSystem/FileSystemExtensions.cs
+++ b/FubarDev.FtpServer.FileSystem/FileSystemExtensions.cs
@@ -44,7 +44,7 @@ namespace FubarDev.FtpServer.FileSystem
         {
             var fullPathOfParent = pathToTestAsParent.GetFullPath();
             var fullPathOfChild = pathToTestAsChild.GetFullPath();
-            var testPathOfChild = fullPathOfChild.Substring(0, Math.Min(fullPathOfChild.Length, fullPathOfChild.Length));
+            var testPathOfChild = fullPathOfChild.Substring(0, Math.Min(fullPathOfParent.Length, fullPathOfChild.Length));
             return fileSystem.FileSystemEntryComparer.Equals(testPathOfChild, fullPathOfParent) && fullPathOfParent.Length <= fullPathOfChild.Length;
         }
 


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

* The 'fullPathOfChild.Length' argument was passed to 'Min' method several times. It is possible that other argument should be passed instead. FubarDev.FtpServer.FileSystem FileSystemExtensions.cs 47