### PR TITLE
Partial fix for #25

### DIFF
--- a/FubarDev.FtpServer.FileSystem/FileSystemExtensions.cs
+++ b/FubarDev.FtpServer.FileSystem/FileSystemExtensions.cs
@@ -105,7 +105,13 @@ namespace FubarDev.FtpServer.FileSystem
                 currentPath.Push(foundDirEntry);
                 currentDir = foundDirEntry;
             }
-            return currentDir;
+
+            // CurrentDir still may not exist (eg. no pathElements were passed to the function and check above was not called)
+            var foundCurrDir = await fileSystem.GetEntryByNameAsync(currentDir, string.Empty, cancellationToken);
+            if (foundCurrDir is IUnixDirectoryEntry)
+                return currentDir;
+            else
+                return null;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #25 for **STOR** command. **PWD**, **CWD** and other commands that modify the `Data.Path` stack without checking for (sub)folder existence are not covered.

I tried to fix the root cause instead of pathing the single STOR command (which is the problem for me), so I hope my fix doesn't break anything else.

It is an ugly hack, so I would appreciate any advice how to fix it in an elegant way.