### PR TITLE
Support for async membership providers

### DIFF
--- a/samples/TestFtpServer/Program.cs
+++ b/samples/TestFtpServer/Program.cs
@@ -228,7 +228,7 @@ namespace TestFtpServer
                 case MembershipProviderType.Anonymous:
                     return builder.EnableAnonymousAuthentication();
                 case MembershipProviderType.Custom:
-                    builder.Services.AddSingleton<IMembershipProvider, CustomMembershipProvider>();
+                    builder.Services.AddSingleton<IBaseMembershipProvider, CustomMembershipProvider>();
                     break;
                 default:
                     throw new InvalidOperationException($"Unknown membership provider {options.MembershipProviderType}");

--- a/src/FubarDev.FtpServer.Abstractions/AccountManagement/IAsyncMembershipProvider.cs
+++ b/src/FubarDev.FtpServer.Abstractions/AccountManagement/IAsyncMembershipProvider.cs
@@ -1,21 +1,15 @@
-//-----------------------------------------------------------------------
-// <copyright file="IMembershipProvider.cs" company="Fubar Development Junker">
-//     Copyright (c) Fubar Development Junker. All rights reserved.
-// </copyright>
-// <author>Mark Junker</author>
-//-----------------------------------------------------------------------
-
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 
 namespace FubarDev.FtpServer.AccountManagement
 {
     /// <summary>
-    /// Membership provider interface.
+    /// Membership provider interface for asynchronous usage.
     /// </summary>
     /// <remarks>
     /// This interface must be implemented to allow the username/password authentication.
     /// </remarks>
-    public interface IMembershipProvider : IBaseMembershipProvider
+    public interface IAsyncMembershipProvider : IBaseMembershipProvider
     {
         /// <summary>
         /// Validates if the combination of <paramref name="username"/> and <paramref name="password"/> is valid.
@@ -23,6 +17,6 @@ namespace FubarDev.FtpServer.AccountManagement
         /// <param name="username">The user name.</param>
         /// <param name="password">The password.</param>
         /// <returns>The result of the validation.</returns>
-        MemberValidationResult ValidateUser([NotNull] string username, [NotNull] string password);
+        Task<MemberValidationResult> ValidateUserAsync([NotNull] string username, [NotNull] string password);
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/AccountManagement/IBaseMembershipProvider.cs
+++ b/src/FubarDev.FtpServer.Abstractions/AccountManagement/IBaseMembershipProvider.cs
@@ -1,0 +1,12 @@
+namespace FubarDev.FtpServer.AccountManagement
+{
+    /// <summary>
+    /// Base Membership provider interface that all membership providers must implement.
+    /// </summary>
+    /// <remarks>
+    /// This interface must be implemented to allow the username/password authentication.
+    /// </remarks>
+    public interface IBaseMembershipProvider
+    {
+    }
+}

--- a/src/FubarDev.FtpServer.Abstractions/FtpConnectionData.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FtpConnectionData.cs
@@ -53,7 +53,7 @@ namespace FubarDev.FtpServer
         /// Gets or sets the membership provider that was used to authenticate the user.
         /// </summary>
         [CanBeNull]
-        public IMembershipProvider AuthenticatedBy { get; set; }
+        public IBaseMembershipProvider AuthenticatedBy { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether the current user is anonymous.

--- a/src/FubarDev.FtpServer.Abstractions/FtpServerBuilderExtensions.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FtpServerBuilderExtensions.cs
@@ -20,7 +20,7 @@ namespace FubarDev.FtpServer
         /// <returns>the server builder used to configure the FTP server.</returns>
         public static IFtpServerBuilder EnableAnonymousAuthentication(this IFtpServerBuilder builder)
         {
-            builder.Services.AddSingleton<IMembershipProvider, AnonymousMembershipProvider>();
+            builder.Services.AddSingleton<IBaseMembershipProvider, AnonymousMembershipProvider>();
             return builder;
         }
     }

--- a/src/FubarDev.FtpServer.Commands/CommandHandlers/PassCommandHandler.cs
+++ b/src/FubarDev.FtpServer.Commands/CommandHandlers/PassCommandHandler.cs
@@ -58,7 +58,7 @@ namespace FubarDev.FtpServer.CommandHandlers
             var password = command.Argument;
             foreach (var membershipProvider in _membershipProviders)
             {
-                var validationResult = await ValidateUser(membershipProvider, Connection.Data.User.Name, password);
+                var validationResult = await ValidateUser(membershipProvider, Connection.Data.User.Name, password).ConfigureAwait(false);
 
                 if (validationResult.IsSuccess)
                 {
@@ -86,7 +86,7 @@ namespace FubarDev.FtpServer.CommandHandlers
         /// <param name="password">The password of the user.</param>
         /// <returns>Returns the <see cref="MemberValidationResult"/> with the result of the validation.</returns>
         /// <exception cref="NotSupportedException">The given membership provider type is not supported.</exception>
-        private async Task<MemberValidationResult> ValidateUser(IBaseMembershipProvider membershipProvider, string username, string password)
+        private static async Task<MemberValidationResult> ValidateUser(IBaseMembershipProvider membershipProvider, string username, string password)
         {
             MemberValidationResult validationResult;
             switch (membershipProvider)


### PR DESCRIPTION
Proposal for #34 that adds the possibility to add asynchronous membership providers. Two new interfaces have been added:
- A new base membership provider that is the base for both (sync and async) membership providers (so that registering it in the IoC container remains basically the same)
- A new `IAsyncMembershipProvider` that offers an async endpoint

The `PassCommandHandler` checks the type of membership provider and performs either a synchronous or an asynchronous call to validate username and password.