### PR TITLE
Special case "Any" IP literals in listener

### DIFF
--- a/src/FubarDev.FtpServer/MultiBindingTcpListener.cs
+++ b/src/FubarDev.FtpServer/MultiBindingTcpListener.cs
@@ -47,11 +47,29 @@ namespace FubarDev.FtpServer
         /// <returns>the task.</returns>
         public async Task StartAsync()
         {
-            var dnsAddresses = await Dns.GetHostAddressesAsync(_address).ConfigureAwait(false);
-            var addresses = dnsAddresses
-                .Where(x => x.AddressFamily == AddressFamily.InterNetwork ||
-                            x.AddressFamily == AddressFamily.InterNetworkV6)
-                .ToList();
+            List<IPAddress> addresses;
+            if (_address == IPAddress.Any.ToString())
+            {
+                // "0.0.0.0"
+                addresses = new List<IPAddress>() { IPAddress.Any };
+            }
+            else if (_address == IPAddress.IPv6Any.ToString())
+            {
+                // "::"
+                addresses = new List<IPAddress>() { IPAddress.IPv6Any };
+            }
+            else if (_address == "*")
+            {
+                addresses = new List<IPAddress>() { IPAddress.Any, IPAddress.IPv6Any };
+            }
+            else
+            {
+                var dnsAddresses = await Dns.GetHostAddressesAsync(_address).ConfigureAwait(false);
+                addresses = dnsAddresses
+                    .Where(x => x.AddressFamily == AddressFamily.InterNetwork ||
+                                x.AddressFamily == AddressFamily.InterNetworkV6)
+                    .ToList();
+            }
             try
             {
                 Port = StartListening(addresses, _port);

--- a/src/FubarDev.FtpServer/MultiBindingTcpListener.cs
+++ b/src/FubarDev.FtpServer/MultiBindingTcpListener.cs
@@ -51,16 +51,16 @@ namespace FubarDev.FtpServer
             if (_address == IPAddress.Any.ToString())
             {
                 // "0.0.0.0"
-                addresses = new List<IPAddress>() { IPAddress.Any };
+                addresses = new List<IPAddress> { IPAddress.Any };
             }
             else if (_address == IPAddress.IPv6Any.ToString())
             {
                 // "::"
-                addresses = new List<IPAddress>() { IPAddress.IPv6Any };
+                addresses = new List<IPAddress> { IPAddress.IPv6Any };
             }
             else if (_address == "*")
             {
-                addresses = new List<IPAddress>() { IPAddress.Any, IPAddress.IPv6Any };
+                addresses = new List<IPAddress> { IPAddress.Any, IPAddress.IPv6Any };
             }
             else
             {


### PR DESCRIPTION
To support binding the listener to "any" IP address, added special cases for `0.0.0.0`, `::`, and `*`.

Changing the ServerAddress option from a string to an IPAddress, as originally proposed, would have broken existing functionality, and allowing either/or would have been messy.

Fixes #43.