### PR TITLE
Allow TCP binding to all IP addresses

### DIFF
--- a/samples/TestFtpServer/Program.cs
+++ b/samples/TestFtpServer/Program.cs
@@ -214,7 +214,7 @@ namespace TestFtpServer
             services.Configure<FtpConnectionOptions>(opt => opt.DefaultEncoding = Encoding.ASCII);
             services.Configure<FtpServerOptions>(opt =>
             {
-                opt.ServerAddress = options.ServerAddress ?? "localhost";
+                opt.ServerAddress = options.ServerAddress;
                 opt.Port = options.GetPort();
             });
 

--- a/samples/TestFtpServer/TestFtpServerOptions.cs
+++ b/samples/TestFtpServer/TestFtpServerOptions.cs
@@ -12,7 +12,7 @@ namespace TestFtpServer
     {
         public bool ShowHelp { get;set; }
 
-        public string ServerAddress { get; set; } = "localhost";
+        public string ServerAddress { get; set; }
         public int? Port { get; set; }
         public bool ImplicitFtps { get; set; }
         public string ServerCertificateFile { get; set; }

--- a/src/FubarDev.FtpServer/FtpServerOptions.cs
+++ b/src/FubarDev.FtpServer/FtpServerOptions.cs
@@ -12,7 +12,7 @@ namespace FubarDev.FtpServer
         /// <summary>
         /// Gets or sets the server address.
         /// </summary>
-        public string ServerAddress { get; set; } = "localhost";
+        public string ServerAddress { get; set; }
 
         /// <summary>
         /// Gets or sets the server port.

--- a/src/FubarDev.FtpServer/MultiBindingTcpListener.cs
+++ b/src/FubarDev.FtpServer/MultiBindingTcpListener.cs
@@ -49,11 +49,21 @@ namespace FubarDev.FtpServer
         /// <returns>the task.</returns>
         public async Task StartAsync()
         {
-            var dnsAddresses = await Dns.GetHostAddressesAsync(_address).ConfigureAwait(false);
-            var addresses = dnsAddresses
-                .Where(x => x.AddressFamily == AddressFamily.InterNetwork ||
-                            x.AddressFamily == AddressFamily.InterNetworkV6)
-                .ToList();
+            IEnumerable<IPAddress> addresses;
+
+            if (!string.IsNullOrEmpty(_address))
+            {
+                var dnsAddresses = await Dns.GetHostAddressesAsync(_address).ConfigureAwait(false);
+                addresses = dnsAddresses
+                    .Where(x => x.AddressFamily == AddressFamily.InterNetwork ||
+                                x.AddressFamily == AddressFamily.InterNetworkV6)
+                    .ToList();
+            }
+            else
+            {
+                addresses = new IPAddress[] { IPAddress.Any };
+            }
+
             try
             {
                 Port = StartListening(addresses, _port);


### PR DESCRIPTION
It might not always be desirable to bind to a specific host name. Sometimes you just want to match to any host name and address. Dropping the default `localhost` and using `IPAddress.Any` will allow this.