### PR TITLE
Cleanly reject an AUTH TLS command if ServerCertificate is null

### DIFF
--- a/src/FubarDev.FtpServer.Commands/CommandHandlers/AuthTlsCommandHandler.cs
+++ b/src/FubarDev.FtpServer.Commands/CommandHandlers/AuthTlsCommandHandler.cs
@@ -56,6 +56,11 @@ namespace FubarDev.FtpServer.CommandHandlers
                 arg = "TLS";
             }
 
+            if (_serverCertificate == null)
+            {
+                return Task.FromResult(new FtpResponse(502, "TLS not configured"));
+            }
+
             switch (arg.ToUpperInvariant())
             {
                 case "TLS":


### PR DESCRIPTION
The default behaviour of FTP clients such as Filezilla and WinSCP, unless configured otherwise, is to connect on Port 21 and then immediately attempt an AUTH TLS before doing anything else. If TLS is not configured, this used to lead to an Exception. While TLS should always be configured in production, this is annoying for quick local tests.

This patch makes FtpServer cleanly reject the AUTH TLS request if no ServerCertificate is configured. Clients will warn the user and fall back to unencrypted FTP.