### PR TITLE
Allow the filesystem to inform the FTP client with FTP error codes

### DIFF
--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/BadParameterException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/BadParameterException.cs
@@ -11,5 +11,8 @@ namespace FubarDev.FtpServer.FileSystem.Error
     {
         /// <inheritdoc />
         public override int FtpErrorCode { get; } = 504;
+
+        /// <inheritdoc />
+        public override string FtpErrorName { get; } = "Command not implemented for that parameter";
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/BadParameterException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/BadParameterException.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 40three GmbH. All rights reserved.
 // </copyright>
 
+using System;
+
 namespace FubarDev.FtpServer.FileSystem.Error
 {
     /// <summary>
@@ -9,6 +11,23 @@ namespace FubarDev.FtpServer.FileSystem.Error
     /// </summary>
     public class BadParameterException : FileSystemException
     {
+        /// <inheritdoc />
+        public BadParameterException()
+        {
+        }
+
+        /// <inheritdoc />
+        public BadParameterException(string message)
+            : base(message)
+        {
+        }
+
+        /// <inheritdoc />
+        public BadParameterException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
         /// <inheritdoc />
         public override int FtpErrorCode { get; } = 504;
 

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/BadParameterException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/BadParameterException.cs
@@ -1,0 +1,15 @@
+// <copyright file="BadParameterException.cs" company="40three GmbH">
+// Copyright (c) 40three GmbH. All rights reserved.
+// </copyright>
+
+namespace FubarDev.FtpServer.FileSystem.Error
+{
+    /// <summary>
+    /// Command not implemented for that parameter.
+    /// </summary>
+    public class BadParameterException : FileSystemException
+    {
+        /// <inheritdoc />
+        public override int FtpErrorCode { get; } = 504;
+    }
+}

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileNameNotAllowedException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileNameNotAllowedException.cs
@@ -11,5 +11,8 @@ namespace FubarDev.FtpServer.FileSystem.Error
     {
         /// <inheritdoc />
         public override int FtpErrorCode { get; } = 553;
+
+        /// <inheritdoc />
+        public override string FtpErrorName { get; } = "File name not allowed";
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileNameNotAllowedException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileNameNotAllowedException.cs
@@ -1,0 +1,15 @@
+// <copyright file="FileNameNotAllowedException.cs" company="40three GmbH">
+// Copyright (c) 40three GmbH. All rights reserved.
+// </copyright>
+
+namespace FubarDev.FtpServer.FileSystem.Error
+{
+    /// <summary>
+    /// Requested action not taken. File name not allowed.
+    /// </summary>
+    public class FileNameNotAllowedException : FileSystemException
+    {
+        /// <inheritdoc />
+        public override int FtpErrorCode { get; } = 553;
+    }
+}

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileNameNotAllowedException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileNameNotAllowedException.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 40three GmbH. All rights reserved.
 // </copyright>
 
+using System;
+
 namespace FubarDev.FtpServer.FileSystem.Error
 {
     /// <summary>
@@ -9,6 +11,23 @@ namespace FubarDev.FtpServer.FileSystem.Error
     /// </summary>
     public class FileNameNotAllowedException : FileSystemException
     {
+        /// <inheritdoc />
+        public FileNameNotAllowedException()
+        {
+        }
+
+        /// <inheritdoc />
+        public FileNameNotAllowedException(string message)
+            : base(message)
+        {
+        }
+
+        /// <inheritdoc />
+        public FileNameNotAllowedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
         /// <inheritdoc />
         public override int FtpErrorCode { get; } = 553;
 

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileSystemException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileSystemException.cs
@@ -1,0 +1,29 @@
+// <copyright file="FileSystemException.cs" company="40three GmbH">
+// Copyright (c) 40three GmbH. All rights reserved.
+// </copyright>
+
+namespace FubarDev.FtpServer.FileSystem.Error
+{
+    /// <summary>
+    /// Represents an error condition the underlying file system wants to communicate to the client.
+    /// </summary>
+    public abstract class FileSystemException : System.Exception
+    {
+        public FileSystemException()
+            : base()
+        {
+        }
+
+        public FileSystemException(string message)
+            : base(message)
+        {
+        }
+
+        public FileSystemException(string message, System.Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public abstract int FtpErrorCode { get; }
+    }
+}

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileSystemException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileSystemException.cs
@@ -12,8 +12,7 @@ namespace FubarDev.FtpServer.FileSystem.Error
         /// <summary>
         ///  Initializes a new instance of the <see cref="FileSystemException"/> class.
         /// </summary>
-        public FileSystemException()
-            : base()
+        protected FileSystemException()
         {
         }
 
@@ -21,7 +20,7 @@ namespace FubarDev.FtpServer.FileSystem.Error
         ///  Initializes a new instance of the <see cref="FileSystemException"/> class.
         /// </summary>
         /// <param name="message">Error message</param>
-        public FileSystemException(string message)
+        protected FileSystemException(string message)
             : base(message)
         {
         }
@@ -31,7 +30,7 @@ namespace FubarDev.FtpServer.FileSystem.Error
         /// </summary>
         /// <param name="message">Error message</param>
         /// <param name="innerException">Underlying exception</param>
-        public FileSystemException(string message, System.Exception innerException)
+        protected FileSystemException(string message, System.Exception innerException)
             : base(message, innerException)
         {
         }

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileSystemException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileSystemException.cs
@@ -25,5 +25,7 @@ namespace FubarDev.FtpServer.FileSystem.Error
         }
 
         public abstract int FtpErrorCode { get; }
+
+        public abstract string FtpErrorName { get; }
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileSystemException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileSystemException.cs
@@ -9,23 +9,41 @@ namespace FubarDev.FtpServer.FileSystem.Error
     /// </summary>
     public abstract class FileSystemException : System.Exception
     {
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="FileSystemException"/> class.
+        /// </summary>
         public FileSystemException()
             : base()
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="FileSystemException"/> class.
+        /// </summary>
+        /// <param name="message">Error message</param>
         public FileSystemException(string message)
             : base(message)
         {
         }
 
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="FileSystemException"/> class.
+        /// </summary>
+        /// <param name="message">Error message</param>
+        /// <param name="innerException">Underlying exception</param>
         public FileSystemException(string message, System.Exception innerException)
             : base(message, innerException)
         {
         }
 
+        /// <summary>
+        /// Gets the FTP error code.
+        /// </summary>
         public abstract int FtpErrorCode { get; }
 
+        /// <summary>
+        /// Gets a human-readable generic error description.
+        /// </summary>
         public abstract string FtpErrorName { get; }
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileUnavailableException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileUnavailableException.cs
@@ -11,5 +11,8 @@ namespace FubarDev.FtpServer.FileSystem.Error
     {
         /// <inheritdoc />
         public override int FtpErrorCode { get; } = 550;
+
+        /// <inheritdoc />
+        public override string FtpErrorName { get; } = "File unavailable";
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileUnavailableException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileUnavailableException.cs
@@ -1,0 +1,15 @@
+// <copyright file="FileUnavailableException.cs" company="40three GmbH">
+// Copyright (c) 40three GmbH. All rights reserved.
+// </copyright>
+
+namespace FubarDev.FtpServer.FileSystem.Error
+{
+    /// <summary>
+    /// Requested action not taken. File unavailable (e.g., file not found, no access).
+    /// </summary>
+    public class FileUnavailableException : FileSystemException
+    {
+        /// <inheritdoc />
+        public override int FtpErrorCode { get; } = 550;
+    }
+}

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileUnavailableException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/FileUnavailableException.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 40three GmbH. All rights reserved.
 // </copyright>
 
+using System;
+
 namespace FubarDev.FtpServer.FileSystem.Error
 {
     /// <summary>
@@ -9,6 +11,23 @@ namespace FubarDev.FtpServer.FileSystem.Error
     /// </summary>
     public class FileUnavailableException : FileSystemException
     {
+        /// <inheritdoc />
+        public FileUnavailableException()
+        {
+        }
+
+        /// <inheritdoc />
+        public FileUnavailableException(string message)
+            : base(message)
+        {
+        }
+
+        /// <inheritdoc />
+        public FileUnavailableException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
         /// <inheritdoc />
         public override int FtpErrorCode { get; } = 550;
 

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/StorageExceededException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/StorageExceededException.cs
@@ -1,0 +1,15 @@
+// <copyright file="StorageExceededException.cs" company="40three GmbH">
+// Copyright (c) 40three GmbH. All rights reserved.
+// </copyright>
+
+namespace FubarDev.FtpServer.FileSystem.Error
+{
+    /// <summary>
+    /// Requested file action aborted. Exceeded storage allocation (for current directory or dataset).
+    /// </summary>
+    public class StorageExceededException : FileSystemException
+    {
+        /// <inheritdoc />
+        public override int FtpErrorCode { get; } = 552;
+    }
+}

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/StorageExceededException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/StorageExceededException.cs
@@ -11,5 +11,8 @@ namespace FubarDev.FtpServer.FileSystem.Error
     {
         /// <inheritdoc />
         public override int FtpErrorCode { get; } = 552;
+
+        /// <inheritdoc />
+        public override string FtpErrorName { get; } = "Storage allocation exceeded";
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/StorageExceededException.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FileSystem/Error/StorageExceededException.cs
@@ -2,6 +2,8 @@
 // Copyright (c) 40three GmbH. All rights reserved.
 // </copyright>
 
+using System;
+
 namespace FubarDev.FtpServer.FileSystem.Error
 {
     /// <summary>
@@ -9,6 +11,23 @@ namespace FubarDev.FtpServer.FileSystem.Error
     /// </summary>
     public class StorageExceededException : FileSystemException
     {
+        /// <inheritdoc />
+        public StorageExceededException()
+        {
+        }
+
+        /// <inheritdoc />
+        public StorageExceededException(string message)
+            : base(message)
+        {
+        }
+
+        /// <inheritdoc />
+        public StorageExceededException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
         /// <inheritdoc />
         public override int FtpErrorCode { get; } = 552;
 

--- a/src/FubarDev.FtpServer/FtpConnection.cs
+++ b/src/FubarDev.FtpServer/FtpConnection.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 
 using FubarDev.FtpServer.BackgroundTransfer;
 using FubarDev.FtpServer.CommandHandlers;
+using FubarDev.FtpServer.FileSystem.Error;
 using JetBrains.Annotations;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -381,8 +382,21 @@ namespace FubarDev.FtpServer
                         }
                         else
                         {
-                            response = await handler.Process(handlerCommand, _cancellationTokenSource.Token).ConfigureAwait(false);
+                            response = await handler.Process(handlerCommand, _cancellationTokenSource.Token)
+                                .ConfigureAwait(false);
                         }
+                    }
+                    catch (FileSystemException fse)
+                    {
+                        var message = fse.Message ?? "Command not executed";
+                        Log?.LogInformation($"Rejected command ({command}) with error {fse.FtpErrorCode}: {message}");
+                        response = new FtpResponse(fse.FtpErrorCode, message);
+                    }
+                    catch (NotSupportedException nse)
+                    {
+                        var message = nse.Message ?? $"Command {command} not supported";
+                        Log?.LogInformation(message);
+                        response = new FtpResponse(502, message);
                     }
                     catch (Exception ex)
                     {

--- a/src/FubarDev.FtpServer/FtpConnection.cs
+++ b/src/FubarDev.FtpServer/FtpConnection.cs
@@ -388,8 +388,8 @@ namespace FubarDev.FtpServer
                     }
                     catch (FileSystemException fse)
                     {
-                        var message = fse.Message ?? "Command not executed";
-                        Log?.LogInformation($"Rejected command ({command}) with error {fse.FtpErrorCode}: {message}");
+                        var message = fse.Message != null ? $"{fse.FtpErrorName}: {fse.Message}" : fse.FtpErrorName;
+                        Log?.LogInformation($"Rejected command ({command}) with error {fse.FtpErrorCode} {message}");
                         response = new FtpResponse(fse.FtpErrorCode, message);
                     }
                     catch (NotSupportedException nse)


### PR DESCRIPTION
If a filesystem imposes restrictions on the allowed interactions - e.g. only certain file names are allowed for upload - there is currently no way to cleanly inform the client about it.

This pull request introduces a few exceptions in the Abstractions/FileSystems that the filesystem can throw and that will be caught by the FtpConnection and returned with the corresponding regular ftp return codes. FtpConnection now also reacts to a NotSupportedException by returning a "502 Command not supported" exception.