### PR TITLE
Added MaxActiveConnections to Ftp Server options

### DIFF
--- a/FubarDev.FtpServer.sln
+++ b/FubarDev.FtpServer.sln
@@ -37,9 +37,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "third-party", "third-party"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "DotNet.Glob", "third-party\DotNet.Glob\DotNet.Glob.shproj", "{A45290B4-20F7-48E9-8543-C69240BFB9F8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FubarDev.FtpServer.FileSystem.InMemory", "src\FubarDev.FtpServer.FileSystem.InMemory\FubarDev.FtpServer.FileSystem.InMemory.csproj", "{E0626E77-87B7-492B-8421-9BB4910252D7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FubarDev.FtpServer.FileSystem.InMemory", "src\FubarDev.FtpServer.FileSystem.InMemory\FubarDev.FtpServer.FileSystem.InMemory.csproj", "{E0626E77-87B7-492B-8421-9BB4910252D7}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		third-party\DotNet.Glob\DotNet.Glob.projitems*{a45290b4-20f7-48e9-8543-c69240bfb9f8}*SharedItemsImports = 13
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/src/FubarDev.FtpServer.Abstractions/IFtpServer.cs
+++ b/src/FubarDev.FtpServer.Abstractions/IFtpServer.cs
@@ -30,6 +30,13 @@ namespace FubarDev.FtpServer
         int Port { get; }
 
         /// <summary>
+        /// Gets the max allows active connections.
+        /// This will cause connections to be refused if count is exceeded.
+        /// 0 (default) means no control over connection count.
+        /// </summary>
+        int MaxActiveConnections { get; }
+
+        /// <summary>
         /// Gets a value indicating whether server ready to receive incoming connectoions.
         /// </summary>
         bool Ready { get; }

--- a/src/FubarDev.FtpServer/FtpServer.cs
+++ b/src/FubarDev.FtpServer/FtpServer.cs
@@ -75,6 +75,7 @@ namespace FubarDev.FtpServer
             _log = logger;
             ServerAddress = serverOptions.Value.ServerAddress;
             Port = serverOptions.Value.Port;
+            MaxActiveConnections = serverOptions.Value.MaxActiveConnections;
         }
 
         /// <inheritdoc />
@@ -88,6 +89,8 @@ namespace FubarDev.FtpServer
 
         /// <inheritdoc />
         public int Port { get; }
+
+        public int MaxActiveConnections { get; }
 
         /// <inheritdoc />
         public bool Ready
@@ -251,6 +254,15 @@ namespace FubarDev.FtpServer
                 var connection = scope.ServiceProvider.GetRequiredService<IFtpConnection>();
                 var connectionAccessor = scope.ServiceProvider.GetRequiredService<IFtpConnectionAccessor>();
                 connectionAccessor.FtpConnection = connection;
+
+                if (MaxActiveConnections != 0 && _statistics.ActiveConnections >= MaxActiveConnections)
+                {
+                    var response = new FtpResponse(10068, "Too many users, server is full.");
+                    connection.WriteAsync(response, CancellationToken.None).Wait();
+                    client.Dispose();
+                    scope.Dispose();
+                    return;
+                }
 
                 if (!_connections.TryAdd(connection, new FtpConnectionInfo(scope)))
                 {

--- a/src/FubarDev.FtpServer/FtpServer.cs
+++ b/src/FubarDev.FtpServer/FtpServer.cs
@@ -90,6 +90,7 @@ namespace FubarDev.FtpServer
         /// <inheritdoc />
         public int Port { get; }
 
+        /// <inheritdoc />
         public int MaxActiveConnections { get; }
 
         /// <inheritdoc />

--- a/src/FubarDev.FtpServer/FtpServerOptions.cs
+++ b/src/FubarDev.FtpServer/FtpServerOptions.cs
@@ -44,6 +44,6 @@ namespace FubarDev.FtpServer
         /// This will cause connections to be refused if count is exceeded.
         /// 0 (default) means no control over connection count.
         /// </summary>
-        public int MaxActiveConnections { get; set; } = 0;
+        public int MaxActiveConnections { get; set; }
     }
 }

--- a/src/FubarDev.FtpServer/FtpServerOptions.cs
+++ b/src/FubarDev.FtpServer/FtpServerOptions.cs
@@ -38,5 +38,12 @@ namespace FubarDev.FtpServer
         /// This may be necessary if you are behind a forwarding firewall, for example.
         /// </summary>
         public string PasvAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the max allows active connections.
+        /// This will cause connections to be refused if count is exceeded.
+        /// 0 (default) means no control over connection count.
+        /// </summary>
+        public int MaxActiveConnections { get; set; } = 0;
     }
 }


### PR DESCRIPTION
Added a new Property to FtpServerOptions - MaxActiveConnections 
Default 0 which allows unlimited connections.
If value is set and active connection count exceeds allowed, the connection will be closed.