### PR TITLE
Fix corrupt file rename in InMemory provider

### DIFF
--- a/src/FubarDev.FtpServer.FileSystem.InMemory/InMemoryFileSystem.cs
+++ b/src/FubarDev.FtpServer.FileSystem.InMemory/InMemoryFileSystem.cs
@@ -101,6 +101,7 @@ namespace FubarDev.FtpServer.FileSystem.InMemory
             lock (targetEntry.ChildrenLock)
             {
                 sourceEntry.Parent = targetEntry;
+                sourceEntry.Name = fileName;
                 targetEntry.Children.Add(fileName, source);
             }
 

--- a/src/FubarDev.FtpServer.FileSystem.InMemory/InMemoryFileSystemEntry.cs
+++ b/src/FubarDev.FtpServer.FileSystem.InMemory/InMemoryFileSystemEntry.cs
@@ -34,7 +34,7 @@ namespace FubarDev.FtpServer.FileSystem.InMemory
         }
 
         /// <inheritdoc />
-        public string Name { get; }
+        public string Name { get; internal set; }
 
         /// <inheritdoc />
         public string Owner { get; private set; }


### PR DESCRIPTION
This PR fixes a bug where the renamed entry does not correctly get the new filename.
This causes that the renamed file cannot be deleted after rename, for example.