### PR TITLE
Custom ServiceUrl for S3 compatible services

### DIFF
--- a/src/FubarDev.FtpServer.FileSystem.S3/S3FileSystem.cs
+++ b/src/FubarDev.FtpServer.FileSystem.S3/S3FileSystem.cs
@@ -34,10 +34,19 @@ namespace FubarDev.FtpServer.FileSystem.S3
         public S3FileSystem(S3FileSystemOptions options, string rootDirectory)
         {
             _options = options;
-            _client = new AmazonS3Client(
-                options.AwsAccessKeyId,
-                options.AwsSecretAccessKey,
-                RegionEndpoint.GetBySystemName(options.BucketRegion));
+
+            var config = new AmazonS3Config();
+
+            if (!string.IsNullOrEmpty(options.ServiceUrl))
+            {
+                config.ServiceURL = options.ServiceUrl;
+            }
+            else
+            {
+                config.RegionEndpoint = RegionEndpoint.GetBySystemName(options.BucketRegion);
+            }
+
+            _client = new AmazonS3Client(options.AwsAccessKeyId, options.AwsSecretAccessKey, config);
             Root = new S3DirectoryEntry(rootDirectory, true);
             _transferUtility = new TransferUtility(_client);
         }

--- a/src/FubarDev.FtpServer.FileSystem.S3/S3FileSystemOptions.cs
+++ b/src/FubarDev.FtpServer.FileSystem.S3/S3FileSystemOptions.cs
@@ -33,6 +33,14 @@ namespace FubarDev.FtpServer.FileSystem.S3
         public string? BucketRegion { get; set; }
 
         /// <summary>
+        /// Gets or sets the S3 service URL.
+        /// </summary>
+        /// <remarks>
+        /// Takes precedence over BucketRegion.
+        /// </remarks>
+        public string? ServiceUrl { get; set; }
+
+        /// <summary>
         /// Gets or sets the S3 bucket name.
         /// </summary>
         public string? BucketName { get; set; }

--- a/src/FubarDev.FtpServer.FileSystem.S3/S3FileSystemProvider.cs
+++ b/src/FubarDev.FtpServer.FileSystem.S3/S3FileSystemProvider.cs
@@ -31,7 +31,7 @@ namespace FubarDev.FtpServer.FileSystem.S3
             if (string.IsNullOrEmpty(_options.AwsAccessKeyId)
                 || string.IsNullOrEmpty(_options.AwsSecretAccessKey)
                 || string.IsNullOrEmpty(_options.BucketName)
-                || string.IsNullOrEmpty(_options.BucketRegion))
+                || (string.IsNullOrEmpty(_options.BucketRegion) && string.IsNullOrEmpty(_options.ServiceUrl)))
             {
                 throw new ArgumentException("S3 Credentials have not been set correctly");
             }


### PR DESCRIPTION
Added the option to override the service url, this makes it possible to use the S3 filesystem with S3 compatible storage providers like DigitalOcean Spaces.

This is the recommended solution by DigitalOcean: https://www.digitalocean.com/community/questions/how-to-use-digitalocean-spaces-with-the-aws-s3-sdks?answer=44888