### PR TITLE
fix(opts command) run server on windows 10,  cmd "opts utf8 on" doesn…

### DIFF
--- a/src/FubarDev.FtpServer.Commands/CommandHandlers/OptsCommandHandler.cs
+++ b/src/FubarDev.FtpServer.Commands/CommandHandlers/OptsCommandHandler.cs
@@ -28,7 +28,7 @@ namespace FubarDev.FtpServer.CommandHandlers
         public override async Task<IFtpResponse?> Process(FtpCommand command, CancellationToken cancellationToken)
         {
             var argument = FtpCommand.Parse(command.Argument);
-            if (!Extensions.TryGetValue(argument.Name, out var extension))
+            if (!Extensions.TryGetValue(argument.Name.ToUpper(), out var extension))
             {
                 return new FtpResponse(500, T("Syntax error, command unrecognized."));
             }

--- a/src/FubarDev.FtpServer.Commands/CommandHandlers/SiteCommandHandler.cs
+++ b/src/FubarDev.FtpServer.Commands/CommandHandlers/SiteCommandHandler.cs
@@ -30,7 +30,7 @@ namespace FubarDev.FtpServer.CommandHandlers
             }
 
             var argument = FtpCommand.Parse(command.Argument);
-            if (!Extensions.TryGetValue(argument.Name, out var extension))
+            if (!Extensions.TryGetValue(argument.Name.ToUpper(), out var extension))
             {
                 return Task.FromResult<IFtpResponse?>(new FtpResponse(500, T("Syntax error, command unrecognized.")));
             }


### PR DESCRIPTION
…'t  work

When run on windows10, cmd " opts utf8 on" "site help" parse error. because in extension cmd is "UTF8" is UPPER.

[15:39:15 DBG] USER tester
[15:39:15 DBG] 331 User tester logged in, needs password
[15:39:15 INF] Connection closed
[15:39:15 DBG] PASS **************** (password omitted)
[15:39:15 DBG] The root directory for tester is /root\tester
[15:39:15 DBG] 230 Password ok, FTP server ready
[15:39:15 DBG] opts utf8 on
[15:39:51 DBG] 500 Syntax error, command unrecognized.

OptsCommandHandler.Process
public override async Task<IFtpResponse?> Process(FtpCommand command, CancellationToken cancellationToken)
        {
            var argument = FtpCommand.Parse(command.Argument);
            if (!Extensions.TryGetValue(argument.Name, out var extension))  <=======  need to UPPER
            {
                return new FtpResponse(500, T("Syntax error, command unrecognized."));
            }

            return await extension.Process(argument, cancellationToken).ConfigureAwait(false);
        }