### PR TITLE
Feature/dotnet 6

### DIFF
--- a/FubarDev.FtpServer.sln
+++ b/FubarDev.FtpServer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28516.95
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32602.215
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FubarDev.FtpServer", "src\FubarDev.FtpServer\FubarDev.FtpServer.csproj", "{01EBBF94-7469-43A0-A618-07FB734B163F}"
 EndProject
@@ -10,13 +10,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.dockerignore = .dockerignore
 		.editorconfig = .editorconfig
 		azure-pipelines.yml = azure-pipelines.yml
+		DotNetSdkMono.props = DotNetSdkMono.props
 		FubarDev.FtpServer.ruleset = FubarDev.FtpServer.ruleset
 		Global.props = Global.props
 		LICENSE.md = LICENSE.md
 		PackageLibrary.props = PackageLibrary.props
 		README.md = README.md
 		stylecop.json = stylecop.json
-		DotNetSdkMono.props = DotNetSdkMono.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FubarDev.FtpServer.FileSystem.DotNet", "src\FubarDev.FtpServer.FileSystem.DotNet\FubarDev.FtpServer.FileSystem.DotNet.csproj", "{9A83C6F5-378B-48B3-B32A-151DB90B390C}"
@@ -70,12 +70,6 @@ EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ReadLine", "third-party\ReadLine\ReadLine.shproj", "{F68F448F-E8A4-4536-9A83-12018B6294B0}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\FubarDev.FtpServer.Shared\FubarDev.FtpServer.Shared.projitems*{52126b62-de83-4597-a832-d144f9a5a870}*SharedItemsImports = 13
-		third-party\DotNet.Glob\DotNet.Glob.projitems*{a45290b4-20f7-48e9-8543-c69240bfb9f8}*SharedItemsImports = 13
-		third-party\ReadLine\ReadLine.projitems*{f68f448f-e8a4-4536-9a83-12018b6294b0}*SharedItemsImports = 13
-		third-party\GnuSslStream\GnuSslStream.projitems*{fd524518-e097-4ac0-aac8-d5ea24f31545}*SharedItemsImports = 13
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -175,5 +169,18 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DAA7D00E-C61D-4640-A54E-D307E4682263}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\FubarDev.FtpServer.Shared\FubarDev.FtpServer.Shared.projitems*{01ebbf94-7469-43a0-a618-07fb734b163f}*SharedItemsImports = 5
+		src\FubarDev.FtpServer.Shared\FubarDev.FtpServer.Shared.projitems*{37ce4218-fac3-4201-82a0-54945698c6ad}*SharedItemsImports = 5
+		src\FubarDev.FtpServer.Shared\FubarDev.FtpServer.Shared.projitems*{474bd381-5b80-4580-bfb1-d41beb70c458}*SharedItemsImports = 5
+		third-party\ReadLine\ReadLine.projitems*{4bda38ca-a19d-4ba9-ac7e-e0b091b3770d}*SharedItemsImports = 5
+		src\FubarDev.FtpServer.Shared\FubarDev.FtpServer.Shared.projitems*{52126b62-de83-4597-a832-d144f9a5a870}*SharedItemsImports = 13
+		third-party\DotNet.Glob\DotNet.Glob.projitems*{7e3f81e2-764e-4075-992f-e53bf50f9623}*SharedItemsImports = 5
+		src\FubarDev.FtpServer.Shared\FubarDev.FtpServer.Shared.projitems*{9a83c6f5-378b-48b3-b32a-151db90b390c}*SharedItemsImports = 5
+		third-party\DotNet.Glob\DotNet.Glob.projitems*{a45290b4-20f7-48e9-8543-c69240bfb9f8}*SharedItemsImports = 13
+		src\FubarDev.FtpServer.Shared\FubarDev.FtpServer.Shared.projitems*{e763936d-dd8d-4392-8075-ca26d7f2ba1e}*SharedItemsImports = 5
+		third-party\ReadLine\ReadLine.projitems*{f68f448f-e8a4-4536-9a83-12018b6294b0}*SharedItemsImports = 13
+		third-party\GnuSslStream\GnuSslStream.projitems*{fd524518-e097-4ac0-aac8-d5ea24f31545}*SharedItemsImports = 13
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ The library is released under the [![MIT license](https://img.shields.io/github/
 
 ## Compilation
 
-* Visual Studio 2019 / C# 8.0
+* Visual Studio 2022 / C# 8.0
 
 ## Using
 
-* Visual Studio 2019
+* Visual Studio 2022
 * .NET Standard 2.0 (everything **except** sample application, PAM authentication)
-* .NET Core 3.0 (sample application, PAM authentication)
+* .NET Core 3.1 (PAM authentication)
 
 ## NuGet packages
 

--- a/samples/QuickStart.AspNetCoreHost/QuickStart.AspNetCoreHost.csproj
+++ b/samples/QuickStart.AspNetCoreHost/QuickStart.AspNetCoreHost.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <IsPackable>false</IsPackable>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/samples/QuickStart.GenericHost/QuickStart.GenericHost.csproj
+++ b/samples/QuickStart.GenericHost/QuickStart.GenericHost.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/QuickStart.GenericHost/QuickStart.GenericHost.csproj
+++ b/samples/QuickStart.GenericHost/QuickStart.GenericHost.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>

--- a/samples/QuickStart/QuickStart.csproj
+++ b/samples/QuickStart/QuickStart.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/QuickStart/QuickStart.csproj
+++ b/samples/QuickStart/QuickStart.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/TestFtpServer.Api/TestFtpServer.Api.csproj
+++ b/samples/TestFtpServer.Api/TestFtpServer.Api.csproj
@@ -2,7 +2,7 @@
   <Import Project="../../Global.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/samples/TestFtpServer.Shell/TestFtpServer.Shell.csproj
+++ b/samples/TestFtpServer.Shell/TestFtpServer.Shell.csproj
@@ -3,7 +3,7 @@
   <Import Project="../../Global.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JKang.IpcServiceFramework.Client" Version="2.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />

--- a/samples/TestFtpServer.Shell/TestFtpServer.Shell.csproj
+++ b/samples/TestFtpServer.Shell/TestFtpServer.Shell.csproj
@@ -18,9 +18,9 @@
   <ItemGroup>
     <PackageReference Include="JKang.IpcServiceFramework.Client" Version="2.2.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Scrutor" Version="3.1.0" />
     <PackageReference Include="System.Interactive.Async" Version="4.0.0" />
   </ItemGroup>

--- a/samples/TestFtpServer/TestFtpServer.csproj
+++ b/samples/TestFtpServer/TestFtpServer.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JKang.IpcServiceFramework.Server" Version="2.3.1" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/samples/TestFtpServer/TestFtpServer.csproj
+++ b/samples/TestFtpServer/TestFtpServer.csproj
@@ -2,24 +2,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Global.props" />
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>ftpserver</AssemblyName>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JKang.IpcServiceFramework.Server" Version="2.2.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
-    <PackageReference Include="Nito.AsyncEx.Context" Version="5.0.0" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="JKang.IpcServiceFramework.Server" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FubarDev.FtpServer.FileSystem.DotNet\FubarDev.FtpServer.FileSystem.DotNet.csproj" />
@@ -29,7 +29,7 @@
     <ProjectReference Include="..\..\src\FubarDev.FtpServer\FubarDev.FtpServer.csproj" />
     <ProjectReference Include="..\TestFtpServer.Api\TestFtpServer.Api.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' or '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup>
     <ProjectReference Include="..\..\src\FubarDev.FtpServer.FileSystem.Unix\FubarDev.FtpServer.FileSystem.Unix.csproj" />
     <ProjectReference Include="..\..\src\FubarDev.FtpServer.MembershipProvider.Pam\FubarDev.FtpServer.MembershipProvider.Pam.csproj" />
   </ItemGroup>

--- a/src/FubarDev.FtpServer.Abstractions/FubarDev.FtpServer.Abstractions.csproj
+++ b/src/FubarDev.FtpServer.Abstractions/FubarDev.FtpServer.Abstractions.csproj
@@ -1,30 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net461;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Interfaces for the portable FTP server</Description>
     <RootNamespace>FubarDev.FtpServer</RootNamespace>
     <PackageTags>portable;FTP;server</PackageTags>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="1.0.0" />
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" PrivateAssets="All" />
-    <PackageReference Include="NGettext" Version="0.6.3" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.1.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="NGettext" Version="0.6.7" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
+    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
   </ItemGroup>
   <Import Project="..\FubarDev.FtpServer.Shared\FubarDev.FtpServer.Shared.projitems" Label="Shared" />
   <Import Project="../../PackageLibrary.props" />

--- a/src/FubarDev.FtpServer.Commands/FubarDev.FtpServer.Commands.csproj
+++ b/src/FubarDev.FtpServer.Commands/FubarDev.FtpServer.Commands.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net461;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Commands for the portable FTP server</Description>
     <RootNamespace>FubarDev.FtpServer</RootNamespace>
     <PackageTags>portable;FTP;server</PackageTags>
@@ -9,14 +9,8 @@
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Abstractions\FubarDev.FtpServer.Abstractions.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.0" />
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" PrivateAssets="All" />
   </ItemGroup>
   <Import Project="..\..\third-party\DotNet.Glob\DotNet.Glob.projitems" Label="Shared" />
 </Project>

--- a/src/FubarDev.FtpServer.FileSystem.DotNet/FubarDev.FtpServer.FileSystem.DotNet.csproj
+++ b/src/FubarDev.FtpServer.FileSystem.DotNet/FubarDev.FtpServer.FileSystem.DotNet.csproj
@@ -1,16 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>.NET file system for portable FTP server</Description>
     <PackageTags>file;system;portable;FTP;server</PackageTags>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.0" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Abstractions\FubarDev.FtpServer.Abstractions.csproj" />
   </ItemGroup>

--- a/src/FubarDev.FtpServer.FileSystem.GoogleDrive/FubarDev.FtpServer.FileSystem.GoogleDrive.csproj
+++ b/src/FubarDev.FtpServer.FileSystem.GoogleDrive/FubarDev.FtpServer.FileSystem.GoogleDrive.csproj
@@ -1,21 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>Google Drive file system for the portable FTP server</Description>
     <PackageTags>portable;FTP;server;Google;Drive</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Apis.Drive.v3" Version="1.39.0.1566" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Abstractions\FubarDev.FtpServer.Abstractions.csproj" />

--- a/src/FubarDev.FtpServer.FileSystem.InMemory/FubarDev.FtpServer.FileSystem.InMemory.csproj
+++ b/src/FubarDev.FtpServer.FileSystem.InMemory/FubarDev.FtpServer.FileSystem.InMemory.csproj
@@ -1,15 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>In-memory file system for portable FTP server</Description>
     <PackageTags>file;system;portable;FTP;server</PackageTags>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.0" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Abstractions\FubarDev.FtpServer.Abstractions.csproj" />
   </ItemGroup>

--- a/src/FubarDev.FtpServer.FileSystem.S3/FubarDev.FtpServer.FileSystem.S3.csproj
+++ b/src/FubarDev.FtpServer.FileSystem.S3/FubarDev.FtpServer.FileSystem.S3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>S3 file system for portable FTP server</Description>
     <PackageTags>portable;FTP;server;AWS;S3</PackageTags>
   </PropertyGroup>
@@ -9,13 +9,6 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.3.104.33" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Options" Version="1.0.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Abstractions\FubarDev.FtpServer.Abstractions.csproj" />
   </ItemGroup>

--- a/src/FubarDev.FtpServer.FileSystem.Unix/FubarDev.FtpServer.FileSystem.Unix.csproj
+++ b/src/FubarDev.FtpServer.FileSystem.Unix/FubarDev.FtpServer.FileSystem.Unix.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Abstractions\FubarDev.FtpServer.Abstractions.csproj" />

--- a/src/FubarDev.FtpServer.MembershipProvider.Pam/FubarDev.FtpServer.MembershipProvider.Pam.csproj
+++ b/src/FubarDev.FtpServer.MembershipProvider.Pam/FubarDev.FtpServer.MembershipProvider.Pam.csproj
@@ -3,18 +3,19 @@
   <Import Project="../../PackageLibrary.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <Description>PAM membership provider for portable FTP server</Description>
     <PackageTags>pam;membership;portable;FTP;server</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FubarDev.PamSharp" Version="0.4.0" />
+    <PackageReference Include="FubarDev.PamSharp" Version="0.5.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Abstractions\FubarDev.FtpServer.Abstractions.csproj" />
+    <ProjectReference Include="..\FubarDev.FtpServer\FubarDev.FtpServer.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/FubarDev.FtpServer.MembershipProvider.Pam/FubarDev.FtpServer.MembershipProvider.Pam.csproj
+++ b/src/FubarDev.FtpServer.MembershipProvider.Pam/FubarDev.FtpServer.MembershipProvider.Pam.csproj
@@ -3,7 +3,7 @@
   <Import Project="../../PackageLibrary.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>PAM membership provider for portable FTP server</Description>
     <PackageTags>pam;membership;portable;FTP;server</PackageTags>
   </PropertyGroup>

--- a/src/FubarDev.FtpServer/FubarDev.FtpServer.csproj
+++ b/src/FubarDev.FtpServer/FubarDev.FtpServer.csproj
@@ -6,7 +6,7 @@
     <PackageTags>portable;FTP;server</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Scrutor" Version="2.0.0" />
+    <PackageReference Include="Scrutor" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Commands\FubarDev.FtpServer.Commands.csproj" />

--- a/src/FubarDev.FtpServer/FubarDev.FtpServer.csproj
+++ b/src/FubarDev.FtpServer/FubarDev.FtpServer.csproj
@@ -1,30 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;netcoreapp2.0;net461;net47;netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Description>TCP-based FTP server implementation</Description>
     <PackageTags>portable;FTP;server</PackageTags>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefineConstants>USE_GNU_SSL_STREAM;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'net47' ">
-    <DefineConstants>USE_SYNC_SSL_STREAM;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Scrutor" Version="2.0.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.1" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Net.Security" Version="4.0.1" />
-    <PackageReference Include="System.Net.NameResolution" Version="4.0.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Commands\FubarDev.FtpServer.Commands.csproj" />
   </ItemGroup>
-  <Import Project="..\..\third-party\GnuSslStream\GnuSslStream.projitems" Label="Shared" Condition=" '$(TargetFramework)' == 'net461' " />
   <Import Project="..\FubarDev.FtpServer.Shared\FubarDev.FtpServer.Shared.projitems" Label="Shared" />
   <Import Project="../../PackageLibrary.props" />
 </Project>

--- a/src/FubarDev.FtpServer/FubarDev.FtpServer.csproj
+++ b/src/FubarDev.FtpServer/FubarDev.FtpServer.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Scrutor" Version="2.0.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FubarDev.FtpServer.Commands\FubarDev.FtpServer.Commands.csproj" />

--- a/test/FubarDev.FtpServer.Tests/FubarDev.FtpServer.Tests.csproj
+++ b/test/FubarDev.FtpServer.Tests/FubarDev.FtpServer.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/test/FubarDev.FtpServer.Tests/FubarDev.FtpServer.Tests.csproj
+++ b/test/FubarDev.FtpServer.Tests/FubarDev.FtpServer.Tests.csproj
@@ -7,8 +7,8 @@
   <ItemGroup>
     <PackageReference Include="FluentFTP" Version="27.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.19" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.19" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/test/FubarDev.FtpServer.Tests/FubarDev.FtpServer.Tests.csproj
+++ b/test/FubarDev.FtpServer.Tests/FubarDev.FtpServer.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Extensions.Logging" Version="1.1.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/test/FubarDev.FtpServer.Tests/FubarDev.FtpServer.Tests.csproj
+++ b/test/FubarDev.FtpServer.Tests/FubarDev.FtpServer.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentFTP" Version="27.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.19" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.19" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.19" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />


### PR DESCRIPTION
- Removing unsupported frameworks - .NET Standard is all you need now.
-  Update support apps to .NET 6.0.
- Update outdated dependencies