### PR TITLE
Remove custom cancellation token handling code, rely on Stream.ReadAsync to handle it instead

### DIFF
--- a/src/FubarDev.FtpServer/FtpConnection.cs
+++ b/src/FubarDev.FtpServer/FtpConnection.cs
@@ -933,38 +933,6 @@ namespace FubarDev.FtpServer
             }
 
             /// <inheritdoc />
-            protected override async Task<int> ReadFromStreamAsync(byte[] buffer, int offset, int length, CancellationToken cancellationToken)
-            {
-                var readTask = Stream
-                   .ReadAsync(buffer, offset, length, cancellationToken);
-
-                var tcs = new TaskCompletionSource<object?>();
-                using var registration = cancellationToken.Register(() => tcs.TrySetResult(null));
-                var resultTask = await Task.WhenAny(readTask, tcs.Task)
-                   .ConfigureAwait(false);
-
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    Logger?.LogTrace("Cancelled through CancellationToken");
-                    return 0;
-                }
-
-                if (resultTask != readTask)
-                {
-                    Logger?.LogTrace("Cancelled through Task.Delay");
-                    return 0;
-                }
-
-#if NETSTANDARD1_3
-                return await readTask.ConfigureAwait(false);
-#else
-                var result = readTask.Result;
-                readTask.Dispose();
-                return result;
-#endif
-            }
-
-            /// <inheritdoc />
             protected override async Task OnCloseAsync(Exception? exception, CancellationToken cancellationToken)
             {
                 await base.OnCloseAsync(exception, cancellationToken)


### PR DESCRIPTION
Fixes #131

I've tried tracing this code back in git history to figure out why this override exists.
[Previously](https://github.com/FubarDevelopment/FtpServer/commit/861210aa874e0bcb0d9aa85eb6f73511e7f318bc) it had a comment:
> We ensure that this service can be closed ASAP with the help of a Task.Delay.

Does `Stream.ReadAsync` take meaningfully longer to cancel than using a `TaskCompletionSource`?.

If there is a reason it is this way, we can probably keep the behaviour and observe the result so that the we don't end up with an UnobservedTaskException later, it'll be a bit clunky though.