### PR TITLE
Replace NGettext dependency

### DIFF
--- a/src/FubarDev.FtpServer.Abstractions/Features/ILocalizationFeature.cs
+++ b/src/FubarDev.FtpServer.Abstractions/Features/ILocalizationFeature.cs
@@ -4,7 +4,7 @@
 
 using System.Globalization;
 
-using NGettext;
+using FubarDev.FtpServer.Localization;
 
 namespace FubarDev.FtpServer.Features
 {
@@ -21,6 +21,6 @@ namespace FubarDev.FtpServer.Features
         /// <summary>
         /// Gets or sets the catalog to be used by the default FTP server implementation.
         /// </summary>
-        ICatalog Catalog { get; set; }
+        ILocalizationCatalog Catalog { get; set; }
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/Features/Impl/LocalizationFeature.cs
+++ b/src/FubarDev.FtpServer.Abstractions/Features/Impl/LocalizationFeature.cs
@@ -6,8 +6,6 @@ using System.Globalization;
 
 using FubarDev.FtpServer.Localization;
 
-using NGettext;
-
 namespace FubarDev.FtpServer.Features.Impl
 {
     /// <summary>
@@ -29,6 +27,6 @@ namespace FubarDev.FtpServer.Features.Impl
         public CultureInfo Language { get; set; }
 
         /// <inheritdoc />
-        public ICatalog Catalog { get; set; }
+        public ILocalizationCatalog Catalog { get; set; }
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/FtpConnectionData.cs
+++ b/src/FubarDev.FtpServer.Abstractions/FtpConnectionData.cs
@@ -22,8 +22,6 @@ using FubarDev.FtpServer.Localization;
 
 using Microsoft.AspNetCore.Http.Features;
 
-using NGettext;
-
 namespace FubarDev.FtpServer
 {
     /// <summary>
@@ -144,7 +142,7 @@ namespace FubarDev.FtpServer
 
         /// <inheritdoc />
         [Obsolete("Query the information using the ILocalizationFeature instead.")]
-        public ICatalog Catalog
+        public ILocalizationCatalog Catalog
         {
             get => _featureCollection.Get<ILocalizationFeature>().Catalog;
             set => _featureCollection.Get<ILocalizationFeature>().Catalog = value;

--- a/src/FubarDev.FtpServer.Abstractions/FubarDev.FtpServer.Abstractions.csproj
+++ b/src/FubarDev.FtpServer.Abstractions/FubarDev.FtpServer.Abstractions.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="NGettext" Version="0.6.7" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />

--- a/src/FubarDev.FtpServer.Abstractions/Localization/EmptyLocalizationCatalog.cs
+++ b/src/FubarDev.FtpServer.Abstractions/Localization/EmptyLocalizationCatalog.cs
@@ -1,0 +1,31 @@
+// <copyright file="EmptyLocalizationCatalog.cs" company="iT Engineering - Software Innovations">
+// Copyright (c) Jan Klass. All rights reserved.
+// </copyright>
+
+using System;
+using System.Globalization;
+
+namespace FubarDev.FtpServer.Localization
+{
+    /// <summary>A localization catalog that returns text as-is.</summary>
+    /// <remarks>
+    ///   <para>The texts in-code are written in English, so the effectively serves as an English catalog by returning texts as-is.</para>
+    ///   <para>The culture formatting for values still applies though.</para>
+    /// </remarks>
+    public class EmptyLocalizationCatalog : ILocalizationCatalog
+    {
+        public EmptyLocalizationCatalog(CultureInfo cultureInfo)
+        {
+            CultureInfo = cultureInfo ?? throw new ArgumentNullException(nameof(cultureInfo));
+            FormatProvider = cultureInfo;
+        }
+
+        public CultureInfo CultureInfo { get; }
+
+        public IFormatProvider FormatProvider { get; }
+
+        public virtual string GetString(string text) => text;
+
+        public virtual string GetString(string text, params object[] args) => string.Format(FormatProvider, text, args);
+    }
+}

--- a/src/FubarDev.FtpServer.Abstractions/Localization/IFtpCatalogLoader.cs
+++ b/src/FubarDev.FtpServer.Abstractions/Localization/IFtpCatalogLoader.cs
@@ -7,8 +7,6 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 
-using NGettext;
-
 namespace FubarDev.FtpServer.Localization
 {
     /// <summary>
@@ -19,7 +17,7 @@ namespace FubarDev.FtpServer.Localization
         /// <summary>
         /// Gets the catalog for the <see cref="DefaultLanguage"/>.
         /// </summary>
-        ICatalog DefaultCatalog { get; }
+        ILocalizationCatalog DefaultCatalog { get; }
 
         /// <summary>
         /// Gets the default language.
@@ -38,6 +36,6 @@ namespace FubarDev.FtpServer.Localization
         /// <param name="language">The language to load the catalog for.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The loaded catalog.</returns>
-        Task<ICatalog> LoadAsync(CultureInfo language, CancellationToken cancellationToken = default);
+        Task<ILocalizationCatalog> LoadAsync(CultureInfo language, CancellationToken cancellationToken = default);
     }
 }

--- a/src/FubarDev.FtpServer.Abstractions/Localization/ILocalizationCatalog.cs
+++ b/src/FubarDev.FtpServer.Abstractions/Localization/ILocalizationCatalog.cs
@@ -1,0 +1,20 @@
+// <copyright file="ILocalizationCatalog.cs" company="iT Engineering - Software Innovations">
+// Copyright (c) Jan Klass. All rights reserved.
+// </copyright>
+
+namespace FubarDev.FtpServer.Localization
+{
+    public interface ILocalizationCatalog
+    {
+        /// <summary>Translate <paramref name="text"/>.</summary>
+        /// <param name="text">The text to be translated.</param>
+        /// <returns>The translated text.</returns>
+        string GetString(string text);
+
+        /// <summary>Translate <paramref name="text"/> with format values <paramref name="args"/>.</summary>
+        /// <param name="text">The text to be translated.</param>
+        /// <param name="args">The format arguments.</param>
+        /// <returns>The translated text.</returns>
+        string GetString(string text, params object[] args);
+    }
+}

--- a/src/FubarDev.FtpServer/Localization/DefaultFtpCatalogLoader.cs
+++ b/src/FubarDev.FtpServer/Localization/DefaultFtpCatalogLoader.cs
@@ -7,8 +7,6 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 
-using NGettext;
-
 namespace FubarDev.FtpServer.Localization
 {
     /// <summary>
@@ -19,7 +17,7 @@ namespace FubarDev.FtpServer.Localization
         private static readonly CultureInfo _defaultLanguage = new CultureInfo("en");
 
         /// <inheritdoc />
-        public ICatalog DefaultCatalog { get; } = new Catalog(_defaultLanguage);
+        public ILocalizationCatalog DefaultCatalog { get; } = new EmptyLocalizationCatalog(_defaultLanguage);
 
         /// <inheritdoc />
         public CultureInfo DefaultLanguage { get; } = _defaultLanguage;
@@ -34,9 +32,9 @@ namespace FubarDev.FtpServer.Localization
         }
 
         /// <inheritdoc />
-        public Task<ICatalog> LoadAsync(CultureInfo language, CancellationToken cancellationToken = default)
+        public Task<ILocalizationCatalog> LoadAsync(CultureInfo language, CancellationToken cancellationToken = default)
         {
-            return Task.FromResult<ICatalog>(new Catalog(language));
+            return Task.FromResult<ILocalizationCatalog>(new EmptyLocalizationCatalog(language));
         }
     }
 }


### PR DESCRIPTION
The FTP protocol supports translation of response texts (while FTP commands and codes never change).

Support for text translations was implemented through `ILocalizationFeature` and the _NGettext_ dependency and its `ICatalog` and `Catalog` types.
The NGettext catalog attempts to load translation files - but by default fails as there are no translation files.

This changeset drops the NGettext dependency in favor of implementing our own interface. The interface surface is reduced by defining only the methods we use (`GetString`).

This is a *breaking change*. The impact is likely very low. Few people will have used or implemented custom translations. For those that did, a fixup is simple.

* Users who previously implemented and registered an ICatalog for custom text translation will have to instead implement ILocalizationCatalog. This is a trivial type reference replacement - the two methods we use are equal on both interfaces.
* Users who made use of NGettext library magic translation file loading (I assume it may identify and load files if placed correctly) will need to implement a simple forwarding catalog type.

References:

* Fixes #144
* RFC 2640 Internationalization of the File Transfer Protocol
* https://github.com/VitaliiTsilnyk/NGettext