### PR TITLE
fix: Ignore remote peer aborts when accepting clients

### DIFF
--- a/src/FubarDev.FtpServer/MultiBindingTcpListener.cs
+++ b/src/FubarDev.FtpServer/MultiBindingTcpListener.cs
@@ -184,6 +184,11 @@ namespace FubarDev.FtpServer
                 // Ignore the exception. This happens when the listener gets stopped.
                 return new AcceptInfo(null, index);
             }
+            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+            {
+                // The remote peer closed the connection during the handshake process. We ignore these.
+                return new AcceptInfo(null, index);
+            }
         }
 
         private int StartListening(IEnumerable<IPAddress> addresses, int port)


### PR DESCRIPTION
Fixes FTP server becoming unresponsive due to stopped listeners.

---

A socket may throw SocketException.
This may occur as early as AcceptTcpClientAsync during initial connect hand-shake.

With this change, a socket exception with the error code 10054 is ignored during client accept. We do not want to stop the listener altogether when a new client closes their connection. That must only close the client connection.

Socket error code 10054: WSAECONNRESET, SocketError.ConnectionReset, 'The connection was reset by the remote peer.'

* https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2
* https://learn.microsoft.com/en-us/dotnet/api/system.net.sockets.socketerror

https://learn.microsoft.com/en-us/dotnet/api/system.net.sockets.tcplistener.accepttcpclientasync

---

The issue is reproducible in a test scenario of generating mass-connects (my tests had 20 times sets of 400 started concurrently as Tasks). The server will consistently become unresponsive (as in, no longer handle new connection requests but still run as a service as if nothing were wrong) after a few hundred connections and connection closings.

I have seen the issue multiple times in production too.