### PR TITLE
fix: Ignore remote peer closed on write (ConnectionReset)

### DIFF
--- a/src/FubarDev.FtpServer/Networking/StreamPipeWriterService.cs
+++ b/src/FubarDev.FtpServer/Networking/StreamPipeWriterService.cs
@@ -73,7 +73,7 @@ namespace FubarDev.FtpServer.Networking
                     await SendDataToStream(readResult.Buffer, CancellationToken.None)
                        .ConfigureAwait(false);
                 }
-                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+                catch (IOException ex) when (ex.InnerException is SocketException { SocketErrorCode: SocketError.ConnectionReset })
                 {
                     Logger?.LogDebug(ex, "Sending data failed. The remote peer closed the connection.");
                     return;

--- a/src/FubarDev.FtpServer/Networking/StreamPipeWriterService.cs
+++ b/src/FubarDev.FtpServer/Networking/StreamPipeWriterService.cs
@@ -6,6 +6,7 @@ using System;
 using System.Buffers;
 using System.IO;
 using System.IO.Pipelines;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -71,6 +72,11 @@ namespace FubarDev.FtpServer.Networking
                     // data might be lost.
                     await SendDataToStream(readResult.Buffer, CancellationToken.None)
                        .ConfigureAwait(false);
+                }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset)
+                {
+                    Logger?.LogDebug(ex, "Sending data failed. The remote peer closed the connection.");
+                    return;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
During writing to a connection stream a socket exception (SocketException) may be thrown.

The socket error SocketError.ConnectionReset (10054 WSAECONNRESET) indicates that the remote peer closed the connection.

This lead to unhandled exceptions being thrown and logged.

Given that this is a client initiated abort, there is no issue on the server side. A debug log level log message is appropriate for that, instead of warning or throwing (unhandled) exceptions.

---

This is reproducible with mass-connects.
In my test scenario I create (sequentially) 20 times (concurrently) 400 TCP connect Tasks.